### PR TITLE
Added support for defining a mapping using an IMapFromAttribute

### DIFF
--- a/Zone.UmbracoMapper/Attributes/IMapFromAttribute.cs
+++ b/Zone.UmbracoMapper/Attributes/IMapFromAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace Zone.UmbracoMapper
+{
+    using System.Reflection;
+
+    /// <summary>
+    /// Attributes which implement this interface can be applied to model properties,
+    /// declaring that the property should be mapped in a specific way
+    /// </summary>
+    public interface IMapFromAttribute
+    {
+        /// <summary>
+        /// Defines how a property value should be set
+        /// </summary>
+        /// <typeparam name="T">Model type</typeparam>
+        /// <param name="fromObject">Data from which to obtain the property value</param>
+        /// <param name="property">Property which we're setting the value of</param>
+        /// <param name="model">Model being populated</param>
+        /// <param name="mapper">Umbraco Mapper instance</param>
+        void SetPropertyValue<T>(object fromObject, PropertyInfo property, T model, IUmbracoMapper mapper);
+    }
+}

--- a/Zone.UmbracoMapper/Zone.UmbracoMapper.csproj
+++ b/Zone.UmbracoMapper/Zone.UmbracoMapper.csproj
@@ -219,6 +219,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\IMapFromAttribute.cs" />
     <Compile Include="Helpers\TypeExtensions.cs" />
     <Compile Include="IPropertyMapping.cs" />
     <Compile Include="Attributes\PropertyMappingAttribute.cs" />


### PR DESCRIPTION
Hey Andy,

I've added support for defining a mapping using an attribute which implements IMapFromAttribute. This could be used to define mappings for properties of various types, but which originate from the same Umbraco data type - e.g. a multi-node tree-picker. I've been using this in a couple of my own projects and it's been working really well.

There aren't many code changes: I've just added the interface, and logic to call its SetPropertyValue method in the appropriate mapping methods. I've only added this to the mapping methods from IPublishedContent and Dictionary<string, object> since it doesn't necessarily make sense in the XElement and JSON mapping methods - what do you think?

Cheers,
Robin