### PR TITLE
Null property fix

### DIFF
--- a/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
+++ b/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml.Linq;
+    //using Microsoft.QualityTools.Testing.Fakes;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using Umbraco.Core.Models;
@@ -456,6 +457,22 @@
             // Assert
             Assert.AreEqual(1000, model.Id);
             Assert.AreEqual(1001, model.ParentId);
+        }
+
+        [TestMethod]
+        public void UmbracoMapper_MapFromIPublishedContent_MapsNullParent()
+        {
+            // Arrange
+            var model = new SimpleViewModel7WithAttribute();
+            var content = MockPublishedContent(mockParent: false);
+            var mapper = GetMapper();
+
+            // Act
+            mapper.Map(content.Object, model);
+
+            // Assert
+            Assert.AreEqual(1000, model.Id);
+            Assert.AreEqual(0, model.ParentId);
         }
 
         [TestMethod]
@@ -2078,7 +2095,8 @@
 
         private Mock<IPublishedContent> MockPublishedContent(int id = 1000, 
             string bodyTextValue = "This is the body text",
-            bool recursiveCall = false)
+            bool recursiveCall = false,
+            bool mockParent = true)
         {
             var summaryTextPropertyMock = new Mock<IPublishedProperty>();
             summaryTextPropertyMock.Setup(c => c.PropertyTypeAlias).Returns("summaryText");
@@ -2141,7 +2159,14 @@
 
             var contentMock = new Mock<IPublishedContent>();
             contentMock.Setup(c => c.Id).Returns(id);
-            contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
+            if (mockParent)
+            {
+                contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
+            }
+            else
+            {
+                contentMock.Setup(c => c.Parent).Returns((IPublishedContent)null);
+            }
             contentMock.Setup(c => c.Name).Returns("Test content");
             contentMock.Setup(c => c.CreatorName).Returns("A.N. Editor");
             contentMock.Setup(c => c.GetProperty(It.Is<string>(x => x == "summaryText"), It.IsAny<bool>())).Returns(summaryTextPropertyMock.Object);

--- a/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
+++ b/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
@@ -459,22 +459,6 @@
         }
 
         [TestMethod]
-        public void UmbracoMapper_MapFromIPublishedContent_MapsNullParent()
-        {
-            // Arrange
-            var model = new SimpleViewModel7WithAttribute();
-            var content = MockPublishedContent(mockParent: false);
-            var mapper = GetMapper();
-
-            // Act
-            mapper.Map(content.Object, model);
-
-            // Assert
-            Assert.AreEqual(1000, model.Id);
-            Assert.AreEqual(0, model.ParentId);
-        }
-
-        [TestMethod]
         public void UmbracoMapper_MapFromIPublishedContent_MapsUsingCustomMapping()
         {
             // Arrange
@@ -2094,8 +2078,7 @@
 
         private Mock<IPublishedContent> MockPublishedContent(int id = 1000, 
             string bodyTextValue = "This is the body text",
-            bool recursiveCall = false,
-            bool mockParent = true)
+            bool recursiveCall = false)
         {
             var summaryTextPropertyMock = new Mock<IPublishedProperty>();
             summaryTextPropertyMock.Setup(c => c.PropertyTypeAlias).Returns("summaryText");
@@ -2158,14 +2141,7 @@
 
             var contentMock = new Mock<IPublishedContent>();
             contentMock.Setup(c => c.Id).Returns(id);
-            if (mockParent)
-            {
-                contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
-            }
-            else
-            {
-                contentMock.Setup(c => c.Parent).Returns((IPublishedContent)null);
-            }
+            contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
             contentMock.Setup(c => c.Name).Returns("Test content");
             contentMock.Setup(c => c.CreatorName).Returns("A.N. Editor");
             contentMock.Setup(c => c.GetProperty(It.Is<string>(x => x == "summaryText"), It.IsAny<bool>())).Returns(summaryTextPropertyMock.Object);

--- a/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
+++ b/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml.Linq;
-    using Microsoft.QualityTools.Testing.Fakes;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using Umbraco.Core.Models;

--- a/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
+++ b/Zone.UmbracoMapper.Tests/UmbracoMapperTests.cs
@@ -459,6 +459,22 @@
         }
 
         [TestMethod]
+        public void UmbracoMapper_MapFromIPublishedContent_MapsNullParent()
+        {
+            // Arrange
+            var model = new SimpleViewModel7WithAttribute();
+            var content = MockPublishedContent(mockParent: false);
+            var mapper = GetMapper();
+
+            // Act
+            mapper.Map(content.Object, model);
+
+            // Assert
+            Assert.AreEqual(1000, model.Id);
+            Assert.AreEqual(0, model.ParentId);
+        }
+
+        [TestMethod]
         public void UmbracoMapper_MapFromIPublishedContent_MapsUsingCustomMapping()
         {
             // Arrange
@@ -2078,7 +2094,8 @@
 
         private Mock<IPublishedContent> MockPublishedContent(int id = 1000, 
             string bodyTextValue = "This is the body text",
-            bool recursiveCall = false)
+            bool recursiveCall = false,
+            bool mockParent = true)
         {
             var summaryTextPropertyMock = new Mock<IPublishedProperty>();
             summaryTextPropertyMock.Setup(c => c.PropertyTypeAlias).Returns("summaryText");
@@ -2141,7 +2158,14 @@
 
             var contentMock = new Mock<IPublishedContent>();
             contentMock.Setup(c => c.Id).Returns(id);
-            contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
+            if (mockParent)
+            {
+                contentMock.Setup(c => c.Parent).Returns(parentContentMock.Object);
+            }
+            else
+            {
+                contentMock.Setup(c => c.Parent).Returns((IPublishedContent)null);
+            }
             contentMock.Setup(c => c.Name).Returns("Test content");
             contentMock.Setup(c => c.CreatorName).Returns("A.N. Editor");
             contentMock.Setup(c => c.GetProperty(It.Is<string>(x => x == "summaryText"), It.IsAny<bool>())).Returns(summaryTextPropertyMock.Object);

--- a/Zone.UmbracoMapper/UmbracoMapper.cs
+++ b/Zone.UmbracoMapper/UmbracoMapper.cs
@@ -982,12 +982,6 @@
                                            Func<string, string> stringValueFormatter = null, 
                                            PropertySet propertySet = PropertySet.All)
         {
-            // If the content we are mapping from is null then we can't map it
-            if (contentToMapFrom == null)
-            {
-                return;
-            }
-
             // First check to see if there's a condition that might mean we don't carry out the mapping
             if (IsMappingConditional(propertyMappings, property.Name) && !IsMappingSpecifiedAsFromRelatedProperty(propertyMappings, property.Name))
             {

--- a/Zone.UmbracoMapper/UmbracoMapper.cs
+++ b/Zone.UmbracoMapper/UmbracoMapper.cs
@@ -982,6 +982,12 @@
                                            Func<string, string> stringValueFormatter = null, 
                                            PropertySet propertySet = PropertySet.All)
         {
+            // If the content we are mapping from is null then we can't map it
+            if (contentToMapFrom == null)
+            {
+                return;
+            }
+
             // First check to see if there's a condition that might mean we don't carry out the mapping
             if (IsMappingConditional(propertyMappings, property.Name) && !IsMappingSpecifiedAsFromRelatedProperty(propertyMappings, property.Name))
             {


### PR DESCRIPTION
This change handles the case when a source property is null.  If the property is null then don't attempt to map it.

Added a test that confirms mapping of a null parent doesn't fall over but just returns 0 instead.