### PR TITLE
Added Umbraco aliases to MediaFile properties

### DIFF
--- a/Zone.UmbracoMapper/BaseDestinationTypes/MediaFile.cs
+++ b/Zone.UmbracoMapper/BaseDestinationTypes/MediaFile.cs
@@ -16,12 +16,16 @@
 
         public string AltText { get; set; }
 
+        [PropertyMapping(SourceProperty = "umbracoWidth")]
         public int Width { get; set; }
 
+        [PropertyMapping(SourceProperty = "umbracoHeight")]
         public int Height { get; set; }
 
+        [PropertyMapping(SourceProperty = "umbracoBytes")]
         public int Size { get; set; }
 
+        [PropertyMapping(SourceProperty = "umbracoExtension")]
         public string FileExtension { get; set; }
     }
 }


### PR DESCRIPTION
To allow mapper to map Width, Height, Size and FileExtension properties.