### PR TITLE
Stopped accessing of parent property when there is no ancestor content

### DIFF
--- a/Zone.UmbracoMapper/UmbracoMapper.cs
+++ b/Zone.UmbracoMapper/UmbracoMapper.cs
@@ -971,7 +971,10 @@
                 levelsAbove = propertyMappings[propName].LevelsAbove;
                 for (int i = 0; i < levelsAbove; i++)
                 {
-                    contentToMapFrom = contentToMapFrom.Parent;
+                    if (contentToMapFrom != null)
+                    {
+                        contentToMapFrom = contentToMapFrom.Parent;
+                    }
                 }
             }
 


### PR DESCRIPTION
When getting the content to map from for levels above, if the level aboves content is null then don't try and access the content's parent otherwise we get a NullReferenceException