### PR TITLE
Fix NullReferenceException when mapping Name to a property value

### DIFF
--- a/Zone.UmbracoMapper.Common/UmbracoMapperBase.cs
+++ b/Zone.UmbracoMapper.Common/UmbracoMapperBase.cs
@@ -329,7 +329,10 @@
             // Concatenation and coalescing only supported/makes sense in this case too.
             if (property.PropertyType.Name == "String")
             {
-                var stringValue = value.ToString();
+                // Prevent null reference exception if a value gets here from NuCache.PublishedContent.Name and the value is null. This can
+                // happen when content with a localised set of values references another piece of content, and that other piece of content
+                // does not have a published version for that language
+                var stringValue = value == null ? null : value.ToString();
                 if (concatenateToExistingValue)
                 {
                     var prefixValueWith = property.GetValue(model) + concatenationSeperator;

--- a/Zone.UmbracoMapper.V8.Tests/UmbracoMapperTests.cs
+++ b/Zone.UmbracoMapper.V8.Tests/UmbracoMapperTests.cs
@@ -47,6 +47,22 @@
             Assert.AreEqual(1000, model.Id);
             Assert.AreEqual("Test content", model.Name);
         }
+        
+        [TestMethod]
+        public void UmbracoMapper_MapFromIPublishedContent_MapsNativePropertiesWithNullName()
+        {
+            // Arrange
+            var model = new SimpleViewModel();
+            var content = MockPublishedContent(name: null);
+            var mapper = GetMapper();
+
+            // Act
+            mapper.Map(content.Object, model);
+
+            // Assert
+            Assert.AreEqual(1000, model.Id);
+            Assert.IsNull(model.Name);
+        }
 
         [TestMethod]
         public void UmbracoMapper_MapFromIPublishedContent_MapsNativePropertiesWithDifferentNames()
@@ -3446,13 +3462,14 @@
         private static Mock<IPublishedContent> MockPublishedContent(int id = 1000, 
                                                                     string bodyTextValue = "This is the body text",
                                                                     bool recursiveCall = false,
-                                                                    bool mockParent = true)
+                                                                    bool mockParent = true,
+                                                                    string name = "Test content")
         {
             var contentMock = new Mock<IPublishedContent>();
             SetUpPropertyMocks(bodyTextValue, recursiveCall, contentMock.As<IPublishedElement>());
 
             contentMock.Setup(c => c.Id).Returns(id);
-            contentMock.Setup(c => c.Name).Returns("Test content");
+            contentMock.Setup(c => c.Name).Returns(name);
             contentMock.Setup(c => c.CreatorName).Returns("A.N. Editor");
 
             SetUpParentContentMock(contentMock, mockParent);


### PR DESCRIPTION
Prevent null reference exception if a value gets mapped from NuCache.PublishedContent.Name and the value is null.

This can happen when content with a localised set of values references another piece of content, and that other piece of content does not have a published version for that language